### PR TITLE
Removal of unnecessary lines and uncommenting targets_all list variable.

### DIFF
--- a/models/Conv_DCFE.py
+++ b/models/Conv_DCFE.py
@@ -96,7 +96,7 @@ class Conv_DCFDE(nn.Module):
 
 ###
 ### The below lines are commented out because unless Conv_DCFDE doesn't get initiated with coef instance variable, it will return
-### an error at line #68 because they aren't defined. coef variables are alpha in the paper: See fig 1. Page no - 2.
+### an error at line #68 because they aren't defined. coef variables are D in the paper: See fig 1. Page no - 2.
 ###
 #if __name__ == '__main__':
 #    layer = Conv_DCFDE(1, 3, kernel_size=3, padding=1, stride=2).cuda()

--- a/models/Conv_DCFE.py
+++ b/models/Conv_DCFE.py
@@ -94,12 +94,15 @@ class Conv_DCFDE(nn.Module):
             ', bases_grad={bases_grad}, mode={mode}, in_channels={in_channels}, out_channels={out_channels}'.format(**self.__dict__)
 
 
-
-if __name__ == '__main__':
-    layer = Conv_DCFDE(1, 3, kernel_size=3, padding=1, stride=2).cuda()
-    # layer = nn.Conv2d(3, 10, kernel_size=3, padding=1, stride=2).cuda()
-    data = torch.randn(1 , 1, 4, 4).cuda()
-    print(layer(data))
-    print(layer(data))
+###
+### The below lines are commented out because unless Conv_DCFDE doesn't get initiated with coef instance variable, it will return
+### an error at line #68 because they aren't defined. coef variables are alpha in the paper: See fig 1. Page no - 2.
+###
+#if __name__ == '__main__':
+#    layer = Conv_DCFDE(1, 3, kernel_size=3, padding=1, stride=2).cuda()
+#    # layer = nn.Conv2d(3, 10, kernel_size=3, padding=1, stride=2).cuda()
+#    data = torch.randn(1 , 1, 4, 4).cuda()
+#    print(layer(data))
+#    print(layer(data))
 
 

--- a/models/resnet18_dcf_bsensemble_imgnet.py
+++ b/models/resnet18_dcf_bsensemble_imgnet.py
@@ -112,7 +112,7 @@ class ResNet(nn.Module):
             self.coeff_list = coeff_list
         
 
-    def add_branch(self, num_outputs, block_expand=0):
+    def add_branch(self, num_outputs):
         """
           add a set of new modules that form another branch
         """

--- a/models/resnet32_dcf_bsensemble.py
+++ b/models/resnet32_dcf_bsensemble.py
@@ -103,7 +103,7 @@ class ResNet(nn.Module):
         for pm in self.coeff_list:
             nn.init.kaiming_normal_(pm)
 
-    def add_branch(self, num_outputs, block_expand=0):
+    def add_branch(self, num_outputs):
         """
           add a set of new modules that form another branch
         """

--- a/train_dcfens_cifar100_CI.py
+++ b/train_dcfens_cifar100_CI.py
@@ -102,7 +102,7 @@ def train(train_loader, epoch, task, model, total_epoch):
     train_loss = 0
     correct = 0
     total = 0
-    # targets_all = []
+    targets_all = []
 
     previous_cls = sum(class_increments[:task])
     for batch_idx, (inputs, targets) in enumerate(train_loader):
@@ -114,7 +114,7 @@ def train(train_loader, epoch, task, model, total_epoch):
         bs = inputs.shape[0]
         outputs, feat_current = model(torch.cat([inputs] * args.num_member, dim=0), task_id=task)
         outputs = outputs.split(bs)
-        # targets_all.append(targets)
+        targets_all.append(targets)
         loss = torch.sum(torch.stack([criterion(outputs_, targets) for outputs_ in outputs], dim=0), dim=0)
         
         loss.backward()

--- a/train_dcfens_cifar100_CI.py
+++ b/train_dcfens_cifar100_CI.py
@@ -412,7 +412,7 @@ for task in range(args.start_from, args.num_task):
     ## dataloaders
     train_loader, test_loader = task_data[task][0],task_data[task][1]
     ## add a new network branch
-    net.add_branch(class_increments[task], task)
+    net.add_branch(class_increments[task])
     net.cuda()
 
     #  init model with previous task's params

--- a/train_dcfens_imgnet100_CI.py
+++ b/train_dcfens_imgnet100_CI.py
@@ -404,7 +404,7 @@ for task in range(args.start_from, args.num_task):
     ## dataloaders
     train_loader, test_loader = task_data[task][0],task_data[task][1]
     ## add a new network branch
-    net.add_branch(class_increments[task], task)
+    net.add_branch(class_increments[task])
     net.cuda()
 
     #  init model with previous task's params


### PR DESCRIPTION
`models/Conv_DCFE.py` -  The __main__ was commented out. It returns an error while running them because of self.coef variable wasn't given to them.

```
Traceback (most recent call last):
  File "/content/CL_Atom_Swapping/./models/Conv_DCFE.py", line 102, in <module>
    print(layer(data))
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/content/CL_Atom_Swapping/./models/Conv_DCFE.py", line 68, in forward
    coef = self.coef.view(self.out_channels, self.in_channels, self.num_bases)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1614, in __getattr__
    raise AttributeError("'{}' object has no attribute '{}'".format(
AttributeError: 'Conv_DCFDE' object has no attribute 'coef'
```

`models/resnet18_dcf_bsensemble_imgnet.py` - Block expand argument was removed. It is useless.

`models/resnet32_dcf_bsensemble.py` - same as before

`train_dcfens_cifar100_CI.py` - some code was commented out (probably for debugging purposes) was added in. Unnecessary arguments from add_branch method were removed.


`train_dcfens_imgnet100_CI.py` - same as before


The code now runs without any error for CIFAR-100 (`/content/CL_Atom_Swapping/train_dcfens_cifar100_CI.py`)
Example output for first few epochs:

Colab (Please remember to enable GPU runtime from Runtime tab) : https://colab.research.google.com/drive/1XxYXgET7wVibtLy3q-6vuci7bx5qzJSH?usp=sharing

```
Args:
Namespace(data_path='Datasets/CIFAR100', num_class=100, num_task=6, first_task_cls=50, dataset='cifar100', train_batch=64, test_batch=128, workers=8, random_classes=False, validation=0.0, overflow=False, model='resnet32', lr=0.01, lr_sub=0.01, lr_schedule='100-200', lr_schedule_sub='100-200', total_epoch=250, total_epoch_sub=250, wd=0.005, wd_sub=0.005, optim='sgd', gpu='0', init_with_pre=True, start_from=0, num_bases=12, num_member=2, add_description='', class_per_task=16, model_path='checkpoints/cifar100_6tasks_firstcls50_member2_resnet32_bases12_wd0.005_sgd')

Files already downloaded and verified
Files already downloaded and verified
Order:  [68, 56, 78, 8, 23, 84, 90, 65, 74, 76, 40, 89, 3, 92, 55, 9, 26, 80, 43, 38, 58, 70, 77, 1, 85, 19, 17, 50, 28, 53, 13, 81, 45, 82, 6, 59, 83, 16, 15, 44, 91, 41, 72, 60, 79, 52, 20, 10, 31, 54, 37, 95, 14, 71, 96, 98, 97, 2, 64, 66, 42, 22, 35, 86, 24, 34, 87, 21, 99, 0, 88, 27, 18, 94, 11, 12, 47, 25, 30, 46, 62, 69, 36, 61, 7, 63, 75, 5, 32, 4, 51, 48, 73, 93, 39, 67, 29, 49, 57, 33]
0
[50, 10, 10, 10, 10, 10]
/usr/local/lib/python3.10/dist-packages/torch/utils/data/dataloader.py:560: UserWarning: This DataLoader will create 16 worker processes in total. Our suggested max number of worker in current system is 2, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.
  warnings.warn(_create_warning_msg(
1
[50, 10, 10, 10, 10, 10]
2
[50, 10, 10, 10, 10, 10]
3
[50, 10, 10, 10, 10, 10]
4
[50, 10, 10, 10, 10, 10]
5
[50, 10, 10, 10, 10, 10]
Training Task :---0
***Optimized Parameters:
0.conv_module.0.weight, 0.conv_module.0.bias, 0.conv_module.1.weight, 0.conv_module.1.bias, 1.conv1.bases, 1.bn1.bn0.weight, 1.bn1.bn0.bias, 1.bn1.bn1.weight, 1.bn1.bn1.bias, 1.conv2.bases, 1.bn2.bn0.weight, 1.bn2.bn0.bias, 1.bn2.bn1.weight, 1.bn2.bn1.bias, 2.conv1.bases, 2.bn1.bn0.weight, 2.bn1.bn0.bias, 2.bn1.bn1.weight, 2.bn1.bn1.bias, 2.conv2.bases, 2.bn2.bn0.weight, 2.bn2.bn0.bias, 2.bn2.bn1.weight, 2.bn2.bn1.bias, 3.conv1.bases, 3.bn1.bn0.weight, 3.bn1.bn0.bias, 3.bn1.bn1.weight, 3.bn1.bn1.bias, 3.conv2.bases, 3.bn2.bn0.weight, 3.bn2.bn0.bias, 3.bn2.bn1.weight, 3.bn2.bn1.bias, 4.conv1.bases, 4.bn1.bn0.weight, 4.bn1.bn0.bias, 4.bn1.bn1.weight, 4.bn1.bn1.bias, 4.conv2.bases, 4.bn2.bn0.weight, 4.bn2.bn0.bias, 4.bn2.bn1.weight, 4.bn2.bn1.bias, 5.conv1.bases, 5.bn1.bn0.weight, 5.bn1.bn0.bias, 5.bn1.bn1.weight, 5.bn1.bn1.bias, 5.conv2.bases, 5.bn2.bn0.weight, 5.bn2.bn0.bias, 5.bn2.bn1.weight, 5.bn2.bn1.bias, 6.conv1.bases, 6.bn1.bn0.weight, 6.bn1.bn0.bias, 6.bn1.bn1.weight, 6.bn1.bn1.bias, 6.conv2.bases, 6.bn2.bn0.weight, 6.bn2.bn0.bias, 6.bn2.bn1.weight, 6.bn2.bn1.bias, 6.downsample.0.weight, 6.downsample.1.bn0.weight, 6.downsample.1.bn0.bias, 6.downsample.1.bn1.weight, 6.downsample.1.bn1.bias, 7.conv1.bases, 7.bn1.bn0.weight, 7.bn1.bn0.bias, 7.bn1.bn1.weight, 7.bn1.bn1.bias, 7.conv2.bases, 7.bn2.bn0.weight, 7.bn2.bn0.bias, 7.bn2.bn1.weight, 7.bn2.bn1.bias, 8.conv1.bases, 8.bn1.bn0.weight, 8.bn1.bn0.bias, 8.bn1.bn1.weight, 8.bn1.bn1.bias, 8.conv2.bases, 8.bn2.bn0.weight, 8.bn2.bn0.bias, 8.bn2.bn1.weight, 8.bn2.bn1.bias, 9.conv1.bases, 9.bn1.bn0.weight, 9.bn1.bn0.bias, 9.bn1.bn1.weight, 9.bn1.bn1.bias, 9.conv2.bases, 9.bn2.bn0.weight, 9.bn2.bn0.bias, 9.bn2.bn1.weight, 9.bn2.bn1.bias, 10.conv1.bases, 10.bn1.bn0.weight, 10.bn1.bn0.bias, 10.bn1.bn1.weight, 10.bn1.bn1.bias, 10.conv2.bases, 10.bn2.bn0.weight, 10.bn2.bn0.bias, 10.bn2.bn1.weight, 10.bn2.bn1.bias, 11.conv1.bases, 11.bn1.bn0.weight, 11.bn1.bn0.bias, 11.bn1.bn1.weight, 11.bn1.bn1.bias, 11.conv2.bases, 11.bn2.bn0.weight, 11.bn2.bn0.bias, 11.bn2.bn1.weight, 11.bn2.bn1.bias, 11.downsample.0.weight, 11.downsample.1.bn0.weight, 11.downsample.1.bn0.bias, 11.downsample.1.bn1.weight, 11.downsample.1.bn1.bias, 12.conv1.bases, 12.bn1.bn0.weight, 12.bn1.bn0.bias, 12.bn1.bn1.weight, 12.bn1.bn1.bias, 12.conv2.bases, 12.bn2.bn0.weight, 12.bn2.bn0.bias, 12.bn2.bn1.weight, 12.bn2.bn1.bias, 13.conv1.bases, 13.bn1.bn0.weight, 13.bn1.bn0.bias, 13.bn1.bn1.weight, 13.bn1.bn1.bias, 13.conv2.bases, 13.bn2.bn0.weight, 13.bn2.bn0.bias, 13.bn2.bn1.weight, 13.bn2.bn1.bias, 14.conv1.bases, 14.bn1.bn0.weight, 14.bn1.bn0.bias, 14.bn1.bn1.weight, 14.bn1.bn1.bias, 14.conv2.bases, 14.bn2.bn0.weight, 14.bn2.bn0.bias, 14.bn2.bn1.weight, 14.bn2.bn1.bias, 15.conv1.bases, 15.bn1.bn0.weight, 15.bn1.bn0.bias, 15.bn1.bn1.weight, 15.bn1.bn1.bias, 15.conv2.bases, 15.bn2.bn0.weight, 15.bn2.bn0.bias, 15.bn2.bn1.weight, 15.bn2.bn1.bias, linears.0.weight, linears.0.bias, linears.1.weight, linears.1.bias, coeff_list.0, coeff_list.1, coeff_list.2, coeff_list.3, coeff_list.4, coeff_list.5, coeff_list.6, coeff_list.7, coeff_list.8, coeff_list.9, coeff_list.10, coeff_list.11, coeff_list.12, coeff_list.13, coeff_list.14, coeff_list.15, coeff_list.16, coeff_list.17, coeff_list.18, coeff_list.19, coeff_list.20, coeff_list.21, coeff_list.22, coeff_list.23, coeff_list.24, coeff_list.25, coeff_list.26, coeff_list.27, coeff_list.28, coeff_list.29
LR Drop Schedule:  [100, 200]

Task: 0, Epoch: 0
[Train: ], [0/250: ], [Accuracy: 9.76], [Loss: 6.950796], [Lr: 0.010000]
[Test TI Acc.: 13.38] [Loss: 3.256159] [Correct: 1.000000]
Saving..

Task: 0, Epoch: 1
[Train: ], [1/250: ], [Accuracy: 19.52], [Loss: 5.938179], [Lr: 0.010000]
[Test TI Acc.: 20.70] [Loss: 3.021781] [Correct: 1.000000]
Saving..

Task: 0, Epoch: 2
[Train: ], [2/250: ], [Accuracy: 26.00], [Loss: 5.370432], [Lr: 0.010000]
[Test TI Acc.: 30.60] [Loss: 2.615830] [Correct: 1.000000]
Saving..

Task: 0, Epoch: 3
[Train: ], [3/250: ], [Accuracy: 31.34], [Loss: 4.930373], [Lr: 0.010000]
[Test TI Acc.: 30.52] [Loss: 2.605773] [Correct: 1.000000]
```